### PR TITLE
decorate ContextListener for flex stateless

### DIFF
--- a/src/Security/EnableListenerDecorator.php
+++ b/src/Security/EnableListenerDecorator.php
@@ -1,0 +1,33 @@
+<?php
+
+
+namespace FlexAuth\Security;
+
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\Security\Http\Firewall\ListenerInterface;
+
+/**
+ * Class EnableListenerDecorator
+ * Allow to switch off listener which was subscribed already
+ *
+ * @author Aleksandr Arofikin <sashaaro@gmail.com>
+ */
+abstract class EnableListenerDecorator implements ListenerInterface
+{
+    /** @var ListenerInterface */
+    protected $listener;
+
+    public function __construct(ListenerInterface $listener)
+    {
+        $this->listener = $listener;
+    }
+
+    public function handle(GetResponseEvent $event)
+    {
+        if ($this->isEnabled()) {
+            $this->listener->handle($event);
+        }
+    }
+
+    abstract public function isEnabled(): bool;
+}

--- a/src/Security/EnableListenerDecorator.php
+++ b/src/Security/EnableListenerDecorator.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace FlexAuth\Security;
 
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;

--- a/src/Security/FlexAuthContextListenerDecorator.php
+++ b/src/Security/FlexAuthContextListenerDecorator.php
@@ -3,7 +3,6 @@
 namespace FlexAuth\Security;
 
 use FlexAuth\FlexAuthTypeProviderInterface;
-use FlexAuth\Type\JWT\JWTUserProviderFactory;
 use Symfony\Component\Security\Http\Firewall\ContextListener;
 
 /**
@@ -18,9 +17,7 @@ class FlexAuthContextListenerDecorator extends EnableListenerDecorator
     /** @var FlexAuthTypeProviderInterface */
     protected $authTypeProvider;
 
-    protected $statelessTypes = [
-        JWTUserProviderFactory::TYPE
-    ];
+    protected $statelessTypes = [];
 
     public function __construct(ContextListener $contextListener, FlexAuthTypeProviderInterface $authTypeProvider)
     {

--- a/src/Security/FlexAuthContextListenerDecorator.php
+++ b/src/Security/FlexAuthContextListenerDecorator.php
@@ -4,9 +4,7 @@ namespace FlexAuth\Security;
 
 use FlexAuth\FlexAuthTypeProviderInterface;
 use FlexAuth\Type\JWT\JWTUserProviderFactory;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Http\Firewall\ContextListener;
-use Symfony\Component\Security\Http\Firewall\ListenerInterface;
 
 /**
  * Allow dynamically determinate firewall is stateless or not.
@@ -15,29 +13,29 @@ use Symfony\Component\Security\Http\Firewall\ListenerInterface;
  * Class FlexAuthContextListenerDecorator
  * @author Aleksandr Arofikin <sashaaro@gmail.com>
  */
-class FlexAuthContextListenerDecorator implements ListenerInterface
+class FlexAuthContextListenerDecorator extends EnableListenerDecorator
 {
     /** @var FlexAuthTypeProviderInterface */
     protected $authTypeProvider;
 
-    /** @var ContextListener */
-    protected $contextListener;
-
     protected $statelessTypes = [
         JWTUserProviderFactory::TYPE
     ];
-    
-    public function __constructor(ContextListener $contextListener, FlexAuthTypeProviderInterface $authTypeProvider)
+
+    public function __construct(ContextListener $contextListener, FlexAuthTypeProviderInterface $authTypeProvider)
     {
-        $this->contextListener = $contextListener;
+        parent::__construct($contextListener);
         $this->authTypeProvider = $authTypeProvider;
     }
 
-    public function handle(GetResponseEvent $event): void
+    public function isEnabled(): bool
     {
-        if (!in_array($this->authTypeProvider->provide()['type'], $this->statelessTypes, true)) {
-            $this->contextListener->handle($event);
-        }
+        return !$this->isStateless();
+    }
+
+    private function isStateless()
+    {
+        return in_array($this->authTypeProvider->provide()['type'], $this->statelessTypes, true);
     }
 
     public function addStatelessType(string $type)

--- a/src/Security/FlexAuthContextListenerDecorator.php
+++ b/src/Security/FlexAuthContextListenerDecorator.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace FlexAuth\Security;
+
+use FlexAuth\FlexAuthTypeProviderInterface;
+use FlexAuth\Type\JWT\JWTUserProviderFactory;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\Security\Http\Firewall\ContextListener;
+use Symfony\Component\Security\Http\Firewall\ListenerInterface;
+
+/**
+ * Allow dynamically determinate firewall is stateless or not.
+ * Serve for switch between login via form with session authentication and jwt which stateless
+ *
+ * Class FlexAuthContextListener
+ * @author Aleksandr Arofikin <sashaaro@gmail.com>
+ */
+class FlexAuthContextListenerDecorator implements ListenerInterface
+{
+    /** @var FlexAuthTypeProviderInterface */
+    protected $authTypeProvider;
+
+    /** @var ContextListener */
+    protected $contextListener;
+
+    protected $statelessTypes = [
+        JWTUserProviderFactory::TYPE
+    ];
+    
+    public function __constructor(ContextListener $contextListener, FlexAuthTypeProviderInterface $authTypeProvider)
+    {
+        $this->contextListener = $contextListener;
+        $this->authTypeProvider = $authTypeProvider;
+    }
+
+    public function handle(GetResponseEvent $event): void
+    {
+        if (!in_array($this->authTypeProvider->provide()['type'], $this->statelessTypes, true)) {
+            $this->contextListener->handle($event);
+        }
+    }
+
+    public function addStatelessType(string $type)
+    {
+        $this->statelessTypes[] = $type;
+    }
+}

--- a/src/Security/FlexAuthContextListenerDecorator.php
+++ b/src/Security/FlexAuthContextListenerDecorator.php
@@ -12,7 +12,7 @@ use Symfony\Component\Security\Http\Firewall\ListenerInterface;
  * Allow dynamically determinate firewall is stateless or not.
  * Serve for switch between login via form with session authentication and jwt which stateless
  *
- * Class FlexAuthContextListener
+ * Class FlexAuthContextListenerDecorator
  * @author Aleksandr Arofikin <sashaaro@gmail.com>
  */
 class FlexAuthContextListenerDecorator implements ListenerInterface


### PR DESCRIPTION
Add special decorator ```FlexAuthContextListenerDecorator``` over ContextListener which allow prevent save secutiry token to session while using jwt authentication dynamically.
Merge with **squash**